### PR TITLE
fix(deploy): preserve node_modules, install deps, restart nivo-enhanced.service

### DIFF
--- a/.github/workflows/deploy-ubuntu.yml
+++ b/.github/workflows/deploy-ubuntu.yml
@@ -28,6 +28,7 @@ jobs:
           mkdir -p "$DEPLOY_PATH"
           rsync -a --delete \
             --exclude '.git/' \
+            --exclude 'node_modules/' \
             --exclude '.env' \
             --exclude 'backend/.env' \
             --exclude 'frontend/.env' \

--- a/scripts/deploy_ubuntu.sh
+++ b/scripts/deploy_ubuntu.sh
@@ -8,19 +8,51 @@ if [[ ! -f .env ]]; then
   exit 1
 fi
 
+# --- Backend: API + worker (Docker) ---
 docker compose up -d postgres redis
 docker compose build api worker
 docker compose up -d api worker
 
+api_healthy=false
 for _ in $(seq 1 60); do
   if curl -fsS http://127.0.0.1:8000/health >/dev/null; then
-    docker compose ps
-    exit 0
+    api_healthy=true
+    break
   fi
   sleep 2
 done
 
-echo "nivo deploy failed health check" >&2
-docker compose ps >&2 || true
-docker logs --tail=120 nivo-api >&2 || true
+if [[ "$api_healthy" != true ]]; then
+  echo "nivo deploy failed health check" >&2
+  docker compose ps >&2 || true
+  docker logs --tail=120 nivo-api >&2 || true
+  exit 1
+fi
+
+docker compose ps
+
+# --- Frontend Node service (nivo-enhanced.service) ---
+# Install workspace deps. The deploy rsync excludes node_modules/, so we
+# keep the existing tree and let npm ci reconcile it against the lockfile.
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+npm ci --no-audit --no-fund
+
+# Restart the Node CRM/Gmail server so it picks up the new code.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+systemctl --user restart nivo-enhanced.service
+
+for _ in $(seq 1 30); do
+  if ss -tlnp 2>/dev/null | grep -q ':3001 '; then
+    echo "nivo-enhanced.service is listening on :3001"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "nivo-enhanced.service did not bind :3001 within 30s" >&2
+systemctl --user status nivo-enhanced.service --no-pager >&2 || true
+journalctl --user -u nivo-enhanced.service -n 80 --no-pager >&2 || true
 exit 1


### PR DESCRIPTION
## Summary

Three latent bugs caused the Ubuntu miniserver to drift silently from `main` after each deploy. Found while investigating why `f24ada3` was on disk but the running Node service was still on `~Apr 24` code.

- **rsync wiped `node_modules`.** `--delete` with no `node_modules/` exclude nuked the workspace's hoisted `node_modules` on every deploy. `nivo-enhanced.service` only kept running because Node had its tsx loader files mmap'd; on restart/reboot it would fail with `MODULE_NOT_FOUND` — which is exactly what happened today when I tried to restart the service.
- **No `npm ci` step.** Even with `node_modules` preserved, dep drift / new deps from `main` were never installed on the live host.
- **The Node service was never restarted.** `deploy_ubuntu.sh` only rebuilt the Docker API + worker, so the systemd-managed `nivo-enhanced.service` kept serving stale code on top of a freshly-deployed backend.

## Changes

- `.github/workflows/deploy-ubuntu.yml`: add `--exclude 'node_modules/'` to the deploy rsync. (Single exclude covers both root and `frontend/node_modules/` — rsync matches anywhere when the pattern has no embedded `/`.)
- `scripts/deploy_ubuntu.sh`:
  - source `nvm` so `npm` is on PATH when invoked from the GHA runner shell
  - run `npm ci --no-audit --no-fund` at the workspace root
  - `systemctl --user restart nivo-enhanced.service`, then verify it rebinds `:3001` within 30s; surface `journalctl` on failure
  - light refactor of the existing API health-check block so it falls through to the new frontend steps instead of `exit 0`-ing on success

## Test plan

- [ ] `workflow_dispatch` this branch's deploy and confirm: rsync log shows no `deleting node_modules/...`, `npm ci` runs, `nivo-enhanced.service` restarts, port 3001 rebinds, exit 0
- [ ] After deploy, `git log -1` on miniserver still shows the deployed ref content baked into the working tree (note: HEAD is intentionally not advanced — the deploy doesn't `git pull`, it just rsyncs the GHA workspace; that's a separate cleanup if we want it)
- [ ] Confirm `nivo-enhanced.service` boot logs show the new `[CRM] Gmail inbound poll every 180s` line after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)