### PR TITLE
fix(deploy): advance local git HEAD to deployed ref

### DIFF
--- a/scripts/deploy_ubuntu.sh
+++ b/scripts/deploy_ubuntu.sh
@@ -8,6 +8,13 @@ if [[ ! -f .env ]]; then
   exit 1
 fi
 
+# --- Sync local git HEAD to the deployed ref ---
+# The workflow rsync only writes the working tree (it excludes .git/), so
+# without this step `git log` on this server keeps showing a stale HEAD
+# even though the files on disk are already at the new ref.
+git fetch origin --quiet
+git reset --hard "${GITHUB_SHA:-origin/main}"
+
 # --- Backend: API + worker (Docker) ---
 docker compose up -d postgres redis
 docker compose build api worker


### PR DESCRIPTION
## Summary

Stacked on top of #23. Fixes the third deploy oddity from that investigation: the workflow rsync excludes `.git/`, so the miniserver's working tree gets updated but its `git log` stays frozen on whatever HEAD it had when someone last did a manual `git pull`. After a deploy, `git status` shows phantom "modifications" — they're really just the files differing from the stale HEAD.

Adds two lines to `scripts/deploy_ubuntu.sh`:

```bash
git fetch origin --quiet
git reset --hard "${GITHUB_SHA:-origin/main}"
```

Run after `rsync`, before the docker / npm / systemctl steps. Falls back to `origin/main` for manual runs where `GITHUB_SHA` isn't in the env.

## Why not just rsync `.git/` too?

Considered and rejected:
- `actions/checkout@v4` is shallow by default (`fetch-depth: 1`) — would ship a 1-commit history
- Even with `fetch-depth: 0`, the runner's checkout writes a token to `.git/config` (via `persist-credentials: true` default), which would leak runner auth onto the dest unless we also flip that off

`git fetch && git reset --hard` from the dest reuses the dest's existing remote auth (which works — verified manually) and avoids both pitfalls.

## Test plan

- [ ] Deploy via `workflow_dispatch` and confirm on miniserver: `git log -1` shows the deployed SHA, `git status` is clean
- [ ] Manually run `bash scripts/deploy_ubuntu.sh` on the server (no `GITHUB_SHA` env) and confirm fallback to `origin/main` works
- [ ] Confirm subsequent `git status` after deploy doesn't list any phantom modifications

## Merge order

Merge #23 first; this PR's base will auto-rebase to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)