### PR TITLE
fix(deploy): advance local git HEAD to deployed ref

### DIFF
--- a/scripts/deploy_ubuntu.sh
+++ b/scripts/deploy_ubuntu.sh
@@ -8,6 +8,13 @@ if [[ ! -f .env ]]; then
   exit 1
 fi
 
+# --- Sync local git HEAD to the deployed ref ---
+# The workflow rsync only writes the working tree (it excludes .git/), so
+# without this step `git log` on this server keeps showing a stale HEAD
+# even though the files on disk are already at the new ref.
+git fetch origin --quiet
+git reset --hard "${GITHUB_SHA:-origin/main}"
+
 # --- Backend: API + worker (Docker) ---
 docker compose up -d postgres redis
 docker compose build api worker


### PR DESCRIPTION
## Summary

Follow-up to #23. The deploy workflow rsync excludes `.git/`, so the working tree on the miniserver gets updated but `git log` / `git status` keep showing a stale HEAD — files appear "modified" relative to it even though they're really the freshly-deployed content.

Adds two lines to `scripts/deploy_ubuntu.sh` (after the `.env` check):

```bash
git fetch origin --quiet
git reset --hard "${GITHUB_SHA:-origin/main}"
```

Falls back to `origin/main` for manual `bash scripts/deploy_ubuntu.sh` runs where `GITHUB_SHA` isn't in the env.

## Why not rsync `.git/` from the runner?

- `actions/checkout@v4` defaults to `fetch-depth: 1` (shallow) — would ship a 1-commit history
- Default `persist-credentials: true` writes the runner's auth token to `.git/config` — would leak runner auth onto the miniserver

`git fetch && git reset --hard` from the dest reuses the miniserver's existing remote auth (verified working) and avoids both.

## Test plan

- [ ] `workflow_dispatch` deploy and confirm: `git log -1` on miniserver shows the deployed SHA, `git status` is clean
- [ ] Run `bash scripts/deploy_ubuntu.sh` manually (no `GITHUB_SHA`) and confirm fallback to `origin/main` works

(Originally opened as #24 stacked on #23. #24 was auto-closed when #23 merged and its base branch was deleted; reopening it isn't allowed by GitHub once the base branch is gone, hence this new PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)